### PR TITLE
docs: add AFIR-04 environment and test baseline

### DIFF
--- a/backend/docs/mvp/mvp-tracker.md
+++ b/backend/docs/mvp/mvp-tracker.md
@@ -1,0 +1,69 @@
+# AFIR-04 – MVP Environment and Test Gap Tracker
+
+## Purpose
+
+This tracker records environment, testing, and integration gaps confirmed during the AFIR-04 baseline review.
+
+The findings below are based on local execution and repository inspection. They are baseline findings only; fixes should be handled through the appropriate follow-up tasks.
+
+## Current Gap and Risk Tracker
+
+| ID | Area | Finding | Status | Risk / Impact | Recommended Follow-up |
+| --- | --- | --- | --- | --- | --- |
+| AFIR04-G01 | Automated Testing | Active `backend/package.json` has only a placeholder `npm test` command. | Open | Backend changes currently lack a repeatable automated regression baseline. | Wire relevant backend tests into the active test workflow. |
+| AFIR04-G02 | Smoke Testing | `newBackend/tests/api.smoke.test.js` imports the non-existent `../BackendCode/app` path. | Open | Existing smoke tests cannot run against the current repository structure as written. | Align the smoke suite with the active backend application structure. |
+| AFIR04-G03 | Backend Startup | `app.js` and `server.js` create separate Express applications. `/health` exists in `app.js` but not in the application started by `npm start`. | Open | Runtime behaviour differs from smoke-test expectations and may create inconsistent validation results. | Establish a single application entry point or align startup and testing. |
+| AFIR04-G04 | Stream API | `mockRepository.getMockData()` is asynchronous, while `mockService.js` consumes the result synchronously. | Open | `/api/stream-names` currently fails at runtime and related stream endpoints may also be affected. | Align service methods with asynchronous repository access. |
+| AFIR04-G05 | Test Data | `timeseries_long` contained 0 rows during baseline validation. | Open | Stream, analytics, and time-series integration cannot be meaningfully validated without representative data. | Establish a controlled baseline dataset or ingestion procedure. |
+| AFIR04-G06 | ThingSpeak | `THINGSPEAK_CHANNEL_ID` is not configured in the local environment. | Blocked | Automatic ThingSpeak polling retries and fails, preventing live ingestion validation. | Confirm the intended project channel/configuration and retest ingestion. |
+| AFIR04-G07 | Authentication | Frontend uses an email/verification-code flow while the current backend uses a different username/password authentication contract. | Open | End-to-end login/verification cannot currently be validated successfully. | Agree and document a shared frontend/backend authentication API contract. |
+| AFIR04-G08 | Routing | Mock routes are included through `routes/index.js` and also mounted directly by `server.js`. | Open | Redundant registration increases routing ambiguity and maintenance risk. | Review route registration and retain one intended mounting path. |
+| AFIR04-G09 | Security Configuration | Authentication falls back to development JWT secrets when environment secrets are absent. | Open | Development defaults could become a security risk if reused outside local development. | Require environment-specific secrets for deployed environments. |
+| AFIR04-G10 | Integration Coverage | CSV ingestion, live ThingSpeak persistence, full series/timestamp flows, and end-to-end authentication were not fully validated in this baseline. | Pending | MVP integration failures may remain undiscovered until these flows are exercised. | Cover these flows in subsequent integration tasks/tests. |
+
+## Confirmed Working Baseline
+
+The following areas were successfully validated during AFIR-04:
+
+- Backend dependencies install successfully.
+- Backend starts successfully on port `3000`.
+- `GET /` returns `Backend is running`.
+- PostgreSQL 18 is operational locally.
+- `IoTDatabase` and the existing project schema were set up successfully.
+- `GET /api/datasets` successfully communicates with PostgreSQL.
+- A temporary dataset was successfully created through `POST /api/datasets`.
+- The created dataset was successfully retrieved through the backend API.
+- The API-created record was independently confirmed in PostgreSQL.
+- Temporary AFIR-04 test data was removed after validation.
+- Frontend dependencies install successfully.
+- Vite frontend starts successfully on port `5173`.
+- Frontend login interface renders successfully.
+
+## Baseline Risks to Share
+
+The highest-priority risks identified from the current baseline are:
+
+1. **No active automated backend regression baseline** – the available smoke suite is disconnected from the current backend structure.
+2. **Runtime/test application inconsistency** – `app.js` and `server.js` do not expose identical behaviour.
+3. **Stream-data path failure** – asynchronous PostgreSQL access is currently consumed incorrectly by the service layer.
+4. **ThingSpeak integration blocked** – live polling cannot be validated without the intended channel configuration.
+5. **Frontend/backend authentication mismatch** – the current authentication contracts prevent complete end-to-end validation.
+6. **Insufficient baseline time-series data** – an empty `timeseries_long` table limits meaningful integration testing.
+7. **Development security defaults** – fallback JWT secrets must not be relied upon in deployed environments.
+
+## AFIR-04 Baseline Status
+
+Environment review: **Completed**
+
+Current smoke/test review: **Completed**
+
+Environment and integration gaps: **Documented**
+
+Risk sharing: **Pending team communication**
+
+Detailed validation evidence is recorded in:
+
+- `backend/docs/mvp/test-plan.md`
+- `backend/docs/mvp/operations-runbook.md`
+
+This tracker should be updated as the identified gaps are assigned, resolved, or revalidated.

--- a/backend/docs/mvp/operations-runbook.md
+++ b/backend/docs/mvp/operations-runbook.md
@@ -1,0 +1,135 @@
+# AFIR-04 – MVP Operations Runbook
+
+## 1. Purpose
+
+This runbook records the local setup and startup assumptions verified during AFIR-04 for the Intelligent IoT Data Management project.
+
+## 2. Environment
+
+Validated local environment:
+
+- Node.js and npm
+- PostgreSQL 18
+- Database: `IoTDatabase`
+- Backend: Node.js + Express
+- Frontend: React + Vite
+- Python 3.12 available for Python components
+
+Default ports:
+
+- Backend: `3000`
+- Frontend: `5173`
+- PostgreSQL: `5432`
+
+## 3. Database Setup
+
+Create the PostgreSQL database:
+
+`IoTDatabase`
+
+Apply the existing schema from:
+
+`backend/src/db/schema.sql`
+
+Configure local database values in:
+
+`backend/.env`
+
+Required database configuration includes:
+
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+
+Credentials and secrets must not be committed to Git.
+
+During AFIR-04, PostgreSQL connectivity was successfully validated through backend dataset read and write operations.
+
+## 4. Backend Setup
+
+From the repository root:
+
+```powershell
+cd backend
+npm install
+npm start
+```
+
+Expected startup:
+
+```text
+Server running on http://localhost:3000
+ThingSpeak polling started. Interval: 60000 ms
+```
+
+Verify the backend by opening:
+
+`http://localhost:3000`
+
+Expected response:
+
+`Backend is running`
+
+The backend currently starts even when ThingSpeak polling fails.
+
+## 5. ThingSpeak Configuration
+
+ThingSpeak polling starts automatically with the backend.
+
+The current local environment is missing:
+
+`THINGSPEAK_CHANNEL_ID`
+
+Therefore, polling currently retries and fails while the Express backend continues running.
+
+The code provides defaults for polling interval, retry count, retry delay, and dataset name.
+
+A valid project ThingSpeak channel configuration is required before live ingestion can be validated.
+
+## 6. Frontend Setup
+
+Open a separate terminal from the repository root:
+
+```powershell
+cd new-frontend\frontend
+npm install
+npm run dev
+```
+
+The frontend was successfully validated at:
+
+`http://localhost:5173`
+
+The login interface renders successfully.
+
+The backend should remain running on port `3000` during frontend integration testing.
+
+## 7. Known Startup and Test Issues
+
+The AFIR-04 baseline identified the following current issues:
+
+- `GET /health` is defined in `app.js` but is not exposed by the normal `server.js` startup path.
+- The existing smoke test references a stale `../BackendCode/app` path.
+- The active backend `npm test` command is a placeholder.
+- `GET /api/stream-names` currently fails because asynchronous PostgreSQL access is consumed synchronously by the service layer.
+- `timeseries_long` contained no baseline data during validation.
+- ThingSpeak cannot complete polling without a configured channel ID.
+- Frontend and backend authentication flows are not currently aligned.
+- Development JWT fallback secrets exist and should not be used for production configuration.
+
+See `test-plan.md` for detailed validation results.
+
+## 8. Recommended Startup Order
+
+1. Start PostgreSQL.
+2. Confirm `IoTDatabase` exists and the schema is applied.
+3. Confirm local `backend/.env` database configuration.
+4. Start the backend with `npm start`.
+5. Confirm `http://localhost:3000` responds.
+6. Start the frontend with `npm run dev`.
+7. Open `http://localhost:5173`.
+8. Monitor the backend terminal for integration errors.
+
+Do not commit `.env`, passwords, JWT secrets, or API keys.

--- a/backend/docs/mvp/test-plan.md
+++ b/backend/docs/mvp/test-plan.md
@@ -1,0 +1,217 @@
+# AFIR-04 – MVP Test Plan and Current Validation Baseline
+
+## 1. Purpose
+
+This document records the current environment and test baseline for the Intelligent IoT Data Management MVP.
+
+The objective of AFIR-04 is to verify the current backend environment, review existing smoke/integration checks, and identify issues affecting backend, PostgreSQL, ThingSpeak, and frontend integration.
+
+Detailed setup instructions are maintained in `operations-runbook.md`, while confirmed gaps and risks are tracked in `mvp-tracker.md`.
+
+## 2. Environment Reviewed
+
+The following local environment was validated:
+
+- Backend: Node.js + Express
+- Database: PostgreSQL 18
+- Local database: `IoTDatabase`
+- Frontend: React + Vite
+- Backend port: `3000`
+- Frontend port: `5173`
+- PostgreSQL port: `5432`
+- Python 3.12 available for Python-based components
+
+Backend and frontend dependencies installed successfully.
+
+The backend starts using:
+
+```text
+npm start
+→ node src/server.js
+```
+
+The frontend starts using:
+
+```text
+npm run dev
+```
+
+## 3. Validation Results
+
+| Check | Result | Observation |
+| --- | --- | --- |
+| Backend dependency installation | PASS | `npm install` completed successfully |
+| Backend startup | PASS | Express starts on port `3000` |
+| `GET /` | PASS | Returns `Backend is running` |
+| PostgreSQL setup | PASS | PostgreSQL 18 and `IoTDatabase` operational |
+| Database schema | PASS | Existing backend schema applied successfully |
+| `GET /api/datasets` | PASS | Returned HTTP `200` and `[]` on clean database |
+| `POST /api/datasets` | PASS | Temporary validation dataset created successfully |
+| `GET /api/datasets/:id` | PASS | Temporary dataset retrieved successfully |
+| Direct PostgreSQL verification | PASS | API-created record confirmed in database |
+| Test-data cleanup | PASS | Temporary AFIR-04 dataset removed |
+| `GET /health` | FAIL | Normal `npm start` application does not expose this route |
+| `GET /api/stream-names` | FAIL | Runtime error in current stream-data path |
+| `timeseries_long` baseline | GAP | Table contained `0` rows |
+| ThingSpeak polling | BLOCKED | `THINGSPEAK_CHANNEL_ID` missing |
+| Existing smoke suite | GAP | Not connected to current backend structure/test command |
+| Backend `npm test` | GAP | Current script is a placeholder |
+| Frontend dependency installation | PASS | `npm install` completed successfully |
+| Frontend startup | PASS | Vite starts on port `5173` |
+| Frontend UI | PASS | Login interface renders |
+| End-to-end authentication | GAP | Frontend/backend authentication contracts are not aligned |
+
+## 4. Backend and PostgreSQL Baseline
+
+Backend-to-PostgreSQL connectivity was validated using the dataset metadata API.
+
+A temporary dataset named:
+
+`AFIR04_BASELINE_TEST`
+
+was created using `POST /api/datasets` and successfully retrieved using `GET /api/datasets/:id`.
+
+The record was independently verified in PostgreSQL and removed after validation.
+
+This confirmed the working path:
+
+```text
+HTTP Request
+→ Express Route
+→ Controller
+→ Service
+→ Repository
+→ PostgreSQL
+→ API Response
+```
+
+The `timeseries_long` table contained `0` rows during baseline testing, so time-series functionality does not currently have populated local baseline data.
+
+## 5. Existing Smoke-Test Review
+
+An existing smoke suite was identified at:
+
+`newBackend/tests/api.smoke.test.js`
+
+It contains checks for:
+
+- `GET /`
+- `GET /health`
+- `GET /api/stream-names`
+- `POST /api/filter-streams`
+- `GET /api/data-profile`
+- `POST /api/top-correlated-pair`
+
+However, the suite imports:
+
+`../BackendCode/app`
+
+which does not exist in the current repository structure.
+
+The current application module is located at:
+
+`backend/src/app.js`
+
+The active `backend/package.json` also contains only a placeholder `npm test` command.
+
+Therefore, the existing smoke suite is not currently runnable through the active backend test workflow.
+
+## 6. Application Startup Observation
+
+The backend contains both:
+
+- `backend/src/app.js`
+- `backend/src/server.js`
+
+`app.js` defines a `/health` endpoint and exports an Express application.
+
+The normal `npm start` workflow instead executes `server.js`, which creates a separate Express application.
+
+As a result:
+
+`GET /health`
+
+through the normally started backend returns:
+
+`Cannot GET /health`
+
+This creates a mismatch between the existing smoke-test expectations and normal runtime behaviour.
+
+## 7. Stream API Observation
+
+Manual validation of:
+
+`GET /api/stream-names`
+
+returned:
+
+```json
+{
+  "error": "Failed to get stream names"
+}
+```
+
+The backend log reported:
+
+`TypeError: Cannot convert undefined or null to object`
+
+Repository review identified that `mockRepository.getMockData()` performs asynchronous PostgreSQL access, while the current service layer consumes the result synchronously without awaiting it.
+
+This is a confirmed implementation gap affecting the stream-data path.
+
+## 8. ThingSpeak Baseline
+
+ThingSpeak polling starts automatically when the backend starts.
+
+Current result: **BLOCKED**
+
+The backend reports:
+
+`THINGSPEAK_CHANNEL_ID is missing in .env`
+
+The service retries three times before reporting the polling failure.
+
+The backend continues running despite the ThingSpeak failure.
+
+A valid project ThingSpeak configuration is required before live ingestion can be validated.
+
+## 9. Frontend Integration Baseline
+
+The React/Vite frontend installs and starts successfully on port `5173`.
+
+The login interface renders successfully.
+
+However, complete authentication could not be validated.
+
+The frontend expects an email/verification-code flow, while the current backend uses a different username/password authentication contract and does not expose the complete verification/resend flow expected by the frontend.
+
+This is therefore recorded as an integration gap rather than a local frontend startup failure.
+
+## 10. Additional Observations
+
+The baseline review also identified:
+
+- Mock routes are registered through `routes/index.js` and again directly in `server.js`.
+- Authentication uses development fallback JWT secrets when environment secrets are absent.
+- CSV ingestion was not validated during this baseline.
+- Live ThingSpeak persistence was not validated because the required channel configuration is unavailable.
+- Automated integration/regression coverage is currently insufficient.
+
+These items are tracked in `mvp-tracker.md` for follow-up.
+
+## 11. Baseline Conclusion
+
+The local development environment is operational for continued MVP integration work.
+
+Backend startup, frontend startup, PostgreSQL connectivity, database schema setup, and dataset metadata read/write operations were successfully validated.
+
+The baseline also identified confirmed gaps involving:
+
+- Automated backend testing
+- Application startup/test consistency
+- Stream-data asynchronous database handling
+- Time-series test-data availability
+- ThingSpeak configuration
+- Frontend/backend authentication alignment
+
+The detailed environment setup is documented in `operations-runbook.md`, and the identified gaps and risks are maintained in `mvp-tracker.md`.


### PR DESCRIPTION
## AFIR-04 – Verify Current Environment and Test Baseline

This PR documents the current MVP environment and validation baseline before further integration work.

### Completed
- Reviewed backend and frontend local environments.
- Validated backend startup and PostgreSQL connectivity.
- Validated dataset API read/write operations.
- Reviewed existing backend smoke tests and current test configuration.
- Reviewed ThingSpeak startup/configuration behaviour.
- Reviewed frontend/backend authentication integration.
- Documented confirmed environment, testing, and integration gaps.

### Key findings
- Existing smoke tests are not wired to the active backend test workflow.
- `/health` behaviour differs between `app.js` and the normal `server.js` startup.
- The stream API currently has an asynchronous database-access issue.
- `timeseries_long` has no baseline data in the validated local environment.
- ThingSpeak validation is blocked by missing channel configuration.
- Frontend and backend authentication flows are not currently aligned.

### Documentation added
- `backend/docs/mvp/test-plan.md`
- `backend/docs/mvp/operations-runbook.md`
- `backend/docs/mvp/mvp-tracker.md`

This PR documents the baseline and identified gaps only. It does not attempt to implement fixes for the identified integration issues.