### PR TITLE
Add dashboard live-data mapping and blocker updates

### DIFF
--- a/backend/docs/mvp/handover.md
+++ b/backend/docs/mvp/handover.md
@@ -1,0 +1,11 @@
+### B-05 frontend cutover findings - 2026-08-04
+### B-05 update – Dashboard live-data cutover
+
+Status: Open
+
+The frontend currently uses `sensorData1.json` through `useSensorData(true)`, causing sensor routes to depend on the same mock source. Time filtering, interval sampling, statistics and correlation are also calculated in the browser.
+
+The shared environment successfully returned 61 `thingspeak-live` rows, but frontend integration and per-sensor differentiation are not yet verified. Statistics, correlation and anomalies depend on BDAI-10, while alerts and alert history depend on BDAI-11.
+
+Exit evidence: Every sensor route must use an approved identifier, display distinct live data and remove supported mock dependencies.
+

--- a/backend/docs/mvp/mvp-tracker.md
+++ b/backend/docs/mvp/mvp-tracker.md
@@ -1,0 +1,19 @@
+## Dashboard live-data mapping
+
+Updated: 2026-08-04
+
+The backend live-data path is working in the configured team environment. ThingSpeak data was saved to PostgreSQL, and `GET /api/datasets/thingspeak-live/series` successfully returned 61 rows.
+
+| Widget                     | Current source           | Live replacement/status       |
+| -------------------------- | ------------------------ | ----------------------------- |
+| Dataset cards              | No confirmed integration | `GET /api/datasets`           |
+| Stream selector            | Mock JSON fields         | Live `thingspeak-live` series |
+| Chart                      | `sensorData1.json`       | Live series API               |
+| Time range and interval    | Browser calculations     | Backend contract pending      |
+| Statistics and correlation | Browser calculations     | Blocked by BDAI-10            |
+| Anomalies and insights     | No live integration      | Blocked by BDAI-10/BDAI-11    |
+| Latest alerts and history  | No live integration      | Blocked by BDAI-11            |
+
+The frontend currently forces mock mode through `useSensorData(true)`. It also performs filtering, interval sampling, statistics and correlation locally. B-05 remains open until every sensor route uses an approved identifier and displays distinct live data.
+
+Local API testing returned HTTP 500 because the PostgreSQL password was rejected and `THINGSPEAK_CHANNEL_ID` was missing. This is a local environment issue; the shared backend live-data test passed.


### PR DESCRIPTION
## Summary

* Added the dashboard widget-to-live-endpoint mapping.
* Identified frontend mock JSON dependencies and browser-local calculations.
* Updated B-05 dashboard cutover findings.
* Recorded BDAI-10 and BDAI-11 dependencies.
* Distinguished the successful shared live-data baseline from local environment configuration failures.

## Current limitations

* The AFI-05 API-contract template is still pending.
* Frontend live cutover requires the approved contract and working local environment configuration.
* Analytics and alert widgets remain dependent on BDAI-10 and BDAI-11.

## Review requested

Please review the widget mappings, blocker ownership and exit evidence.
