### PR TITLE
AFI-10: Finalize live route mounting and replace mock-first integration

### DIFF
--- a/backend/docs/mvp/api-contract.md
+++ b/backend/docs/mvp/api-contract.md
@@ -155,3 +155,134 @@ The frontend and backend already have a broadly compatible wide-format time-seri
 The primary issue is not the absence of a backend series API. The main integration gap is that the active Dashboard remains configured to load mock data and does not currently use the selected dataset to request the corresponding dataset-aware backend series.
 
 Future implementation should be handled separately from this audit.
+---
+
+# AFI-07 Frontend-Ready Response Standards
+
+## Purpose
+
+This section defines the recommended response structures for the backend APIs so that frontend components receive consistent JSON payloads. These standards are intended to support future frontend and backend integration and reduce inconsistencies across API endpoints.
+
+---
+
+## Standard Response Format
+
+Every successful API response should follow this structure:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "message": "Request completed successfully"
+}
+```
+
+Every failed API response should follow this structure:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 500,
+    "message": "Failed to load resource"
+  }
+}
+```
+
+---
+
+## Series Response
+
+Route:
+
+GET `/api/datasets/:name/series`
+
+Recommended response:
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "created_at": "2026-07-30T10:00:00Z",
+      "entry_id": 1,
+      "field1": 25.4,
+      "field2": 60.2
+    }
+  ],
+  "message": "Series data loaded successfully"
+}
+```
+
+---
+
+## Analytics Response
+
+Route:
+
+POST `/api/analyse`
+
+Recommended response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "analysis": {
+      "highestCorrelation": {
+        "stream1": "field1",
+        "stream2": "field2",
+        "score": 0.94
+      }
+    }
+  },
+  "message": "Analysis completed successfully"
+}
+```
+
+---
+
+## Alert Response
+
+Recommended response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "alerts": [
+      {
+        "id": 1,
+        "severity": "High",
+        "message": "Temperature exceeded threshold",
+        "created_at": "2026-07-30T10:00:00Z"
+      }
+    ]
+  },
+  "message": "Alerts loaded successfully"
+}
+```
+
+---
+
+## Error Response
+
+Recommended response:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "message": "Requested resource was not found"
+  }
+}
+```
+
+---
+
+## Response Standard Notes
+
+The recommended response format provides a consistent structure for successful and failed requests. Returning a standard JSON object containing success, data, message and error fields allows frontend components to process responses uniformly without implementing route-specific parsing logic.
+
+These standards are proposed for future implementation and do not modify the current backend behaviour observed during the AFIR-02 audit.

--- a/backend/docs/mvp/api-contract.md
+++ b/backend/docs/mvp/api-contract.md
@@ -1,0 +1,157 @@
+# AFIR-02 Frontend / Backend API Cross-Reference
+
+## Purpose
+
+This document cross-references the frontend dashboard data requirements identified during AFIR-02 with the backend API routes currently available in the project.
+
+This is an audit document only. No API contracts or implementation code were changed.
+
+## API Cross-Reference
+
+| Backend Route | Method | Frontend Use / Candidate | Current Status |
+|---|---|---|---|
+| `/api/datasets` | GET | Dataset discovery/listing | Available |
+| `/api/datasets/:id` | GET | Dataset metadata lookup | Available |
+| `/api/datasets/:name/series` | GET | Primary candidate for dashboard sensor/time-series data | Available, not currently wired to Dashboard |
+| `/api/datasets/:name/series/filter` | POST | Selected metric/stream filtering | Available, not currently wired to Dashboard |
+| `/api/datasets/:name/timestamps` | GET | Time-range/timestamp support | Available, not currently wired to Dashboard |
+| `/api/streams` | GET | Existing endpoint referenced by `useSensorData` when mock mode is disabled | Existing mock-oriented path; not the preferred dataset-aware integration route |
+| `/api/stream-names` | GET | Available stream discovery | Existing mock-oriented path |
+| `/api/filter-streams` | POST | Stream filtering | Existing mock-oriented path |
+| `/api/data-profile` | GET | Potential statistics/profile support | Existing mock-oriented path |
+| `/api/top-correlated-pair` | POST | Potential correlation support | Existing mock-oriented path |
+| `/api/analyse` | POST | Generic analysis | Placeholder implementation only |
+
+## Primary Dashboard Data Contract
+
+The current frontend dashboard expects time-series rows broadly shaped as:
+
+```json
+{
+  "created_at": "timestamp",
+  "entry_id": 1,
+  "metricName": 123.45
+}
+```
+
+Additional metric fields are discovered dynamically by the frontend.
+
+The dataset-aware backend series service also produces wide-format entries containing:
+
+- `created_at`
+- `entry_id`
+- dynamic metric fields
+
+Therefore:
+
+`GET /api/datasets/:name/series`
+
+is the strongest existing backend candidate for future live dashboard integration.
+
+## Frontend Current Data Path
+
+The active Dashboard currently uses:
+
+`useSensorData(true)`
+
+Mock mode loads:
+
+`src/data/sensorData1.json`
+
+The same hook defines `/api/streams` as its default API endpoint when mock mode is disabled.
+
+However, the current backend architecture also provides dataset-aware APIs under:
+
+`/api/datasets/:name/...`
+
+These routes are better aligned with the application's dataset-specific dashboard route:
+
+`/dashboard/:id`
+
+## Dataset Series
+
+### GET `/api/datasets/:name/series`
+
+Purpose:
+
+Returns wide-format time-series entries for the requested dataset.
+
+Potential frontend consumers:
+
+- Main dashboard dataset
+- Stream discovery
+- Stream statistics
+- Scatter plots
+- Correlation calculations
+- Line charts
+- Frontend time filtering
+
+Integration status:
+
+**Available but not currently connected to the active Dashboard.**
+
+## Dataset Series Filtering
+
+### POST `/api/datasets/:name/series/filter`
+
+Expected request body:
+
+```json
+{
+  "streamNames": ["field1", "field2"]
+}
+```
+
+Purpose:
+
+Returns dataset entries restricted to selected metric names.
+
+Integration status:
+
+**Available but not currently connected to the frontend stream-selection flow.**
+
+The frontend currently performs additional filtering locally, including time range, entry ID range and interval sampling.
+
+## Dataset Timestamps
+
+### GET `/api/datasets/:name/timestamps`
+
+Purpose:
+
+Returns the timestamps associated with a dataset.
+
+Potential frontend consumer:
+
+`useTimeRange`
+
+Integration status:
+
+**Available but not currently connected.**
+
+## Mock-Oriented Routes
+
+The following routes belong to the existing mock/processed-data flow:
+
+- `GET /api/streams`
+- `GET /api/stream-names`
+- `POST /api/filter-streams`
+- `GET /api/data-profile`
+- `POST /api/top-correlated-pair`
+
+These provide functionality similar to several frontend operations, but they are not currently dataset-aware replacements for the database-backed dashboard flow.
+
+## Analysis
+
+### POST `/api/analyse`
+
+The route exists, but the current service implementation only returns the submitted payload with a placeholder completion message.
+
+Therefore, it should not currently be treated as a production analysis API.
+
+## AFIR-02 Conclusion
+
+The frontend and backend already have a broadly compatible wide-format time-series contract.
+
+The primary issue is not the absence of a backend series API. The main integration gap is that the active Dashboard remains configured to load mock data and does not currently use the selected dataset to request the corresponding dataset-aware backend series.
+
+Future implementation should be handled separately from this audit.

--- a/backend/docs/mvp/api-contract.md
+++ b/backend/docs/mvp/api-contract.md
@@ -74,7 +74,36 @@ These routes are better aligned with the application's dataset-specific dashboar
 
 Purpose:
 
-Returns wide-format time-series entries for the requested dataset.
+Returns wide-format time-series entries for the requested dataset using the dataset name/slug.
+
+### Request
+
+```http
+GET /api/datasets/{datasetName}/series
+```
+
+Example:
+
+```http
+GET /api/datasets/thingspeak-live/series
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "created_at": "2026-07-30T10:00:00Z",
+      "entry_id": 1,
+      "field1": 25.4,
+      "field2": 60.2
+    }
+  ],
+  "message": "Series data loaded successfully"
+}
+```
 
 Potential frontend consumers:
 
@@ -88,7 +117,7 @@ Potential frontend consumers:
 
 Integration status:
 
-**Available but not currently connected to the active Dashboard.**
+**Available for live dashboard integration using the dataset name/slug. Numeric database IDs should only be used for the separate `GET /api/datasets/:id` endpoint.**
 
 ## Dataset Series Filtering
 

--- a/backend/docs/mvp/evidence/api-samples.json
+++ b/backend/docs/mvp/evidence/api-samples.json
@@ -1,0 +1,51 @@
+{
+  "seriesResponse": {
+    "success": true,
+    "data": [
+      {
+        "created_at": "2026-07-30T10:00:00Z",
+        "entry_id": 1,
+        "field1": 25.4,
+        "field2": 60.2
+      }
+    ],
+    "message": "Series data loaded successfully"
+  },
+
+  "analyticsResponse": {
+    "success": true,
+    "data": {
+      "analysis": {
+        "highestCorrelation": {
+          "stream1": "field1",
+          "stream2": "field2",
+          "score": 0.94
+        }
+      }
+    },
+    "message": "Analysis completed successfully"
+  },
+
+  "alertResponse": {
+  "success": true,
+  "data": {
+    "alerts": [
+      {
+        "id": 1,
+        "severity": "High",
+        "message": "Temperature exceeded threshold",
+        "created_at": "2026-07-30T10:00:00Z"
+      }
+    ]
+  },
+  "message": "Alerts loaded successfully"
+},
+
+  "errorResponse": {
+    "success": false,
+    "error": {
+      "code": 404,
+      "message": "Requested resource was not found"
+    }
+  }
+}

--- a/backend/docs/mvp/handover.md
+++ b/backend/docs/mvp/handover.md
@@ -1,0 +1,114 @@
+# AFIR-02 Frontend Integration Handover
+
+## Overview
+
+AFIR-02 reviewed the active frontend dashboard to identify its current mock-data dependencies and compare them with backend capabilities already available in the project.
+
+This task is an audit only. No frontend or backend implementation changes were made.
+
+## Current Frontend Behaviour
+
+The active dashboard is accessed through:
+
+`/dashboard/:id`
+
+`DashboardPage.jsx` receives the dataset ID from the route and passes it to the Dashboard component.
+
+The Dashboard currently loads sensor data using:
+
+`useSensorData(true)`
+
+Because mock mode is enabled, `useSensorData.js` loads:
+
+`src/data/sensorData1.json`
+
+instead of retrieving the selected dataset from the backend.
+
+As a result, selecting a dataset does not currently cause the dashboard sensor widgets to retrieve that dataset's live database-backed time-series data.
+
+## Dashboard Dependencies Reviewed
+
+The following dashboard functionality was reviewed:
+
+- Sensor data loading
+- Stream discovery
+- Time-range extraction
+- Time and entry filtering
+- Interval sampling
+- Stream statistics
+- Correlation analysis
+- Scatter plots
+- Most-correlated-pair analysis
+- Line charts
+
+Most of these components operate on data supplied to them and are not inherently restricted to mock data.
+
+Their current mock dependency originates primarily from the Dashboard's initial data source.
+
+## Existing Backend Integration Candidates
+
+The strongest existing live-data candidate is:
+
+`GET /api/datasets/:name/series`
+
+The backend describes this route as the main controller for real sensor/time-series data.
+
+The associated timeseries service supports both wide-format ThingSpeak data and long-format CSV data converted into wide-format entries.
+
+The returned structure includes:
+
+- `created_at`
+- `entry_id`
+- dynamic metric fields
+
+This is broadly compatible with the structure currently consumed by the dashboard.
+
+Additional relevant backend capability includes:
+
+`GET /api/datasets/:name/timestamps`
+
+This returns timestamps for a selected dataset and could support future time-range integration.
+
+`POST /api/datasets/:name/series/filter`
+
+This supports filtering dataset series by selected metric names.
+
+## Existing Mock-Oriented Backend Routes
+
+The project also contains:
+
+- `GET /api/streams`
+- `GET /api/stream-names`
+- `POST /api/filter-streams`
+- `GET /api/data-profile`
+- `POST /api/top-correlated-pair`
+
+These routes are associated with the existing mock/processed-data service path.
+
+They should not be assumed to provide dataset-aware database integration without further implementation work.
+
+## Analysis Endpoint
+
+`POST /api/analyse` currently exists, but its service is a placeholder.
+
+It returns the received payload with an analysis-completed message and does not currently perform real statistical or machine-learning analysis.
+
+## Main Integration Gaps
+
+1. Dashboard data loading is explicitly configured for mock mode.
+
+2. The selected dashboard dataset is not currently used to load the corresponding backend time-series data.
+
+3. Dataset-aware backend APIs exist but are not wired into the active dashboard data-loading flow.
+
+4. Some analytical backend endpoints remain tied to the mock-data path rather than a selected database dataset.
+
+5. The generic analyse endpoint is not yet a real analysis implementation.
+
+## Recommended Follow-Up
+
+Future integration work should connect the dashboard's selected dataset to the dataset-aware series API while preserving the existing frontend data contract.
+
+Any replacement of frontend-side filtering, statistics or correlation logic should be handled as separate implementation work and tested against the expected frontend response structure.
+
+AFIR-02 does not make those implementation changes.

--- a/backend/docs/mvp/mvp-tracker.md
+++ b/backend/docs/mvp/mvp-tracker.md
@@ -1,0 +1,88 @@
+# AFIR-02 Frontend Mock Dependency Audit
+
+## Purpose
+
+This document records the current frontend dashboard dependencies and identifies where mock data is currently used, which existing backend routes could support future live integration, and which gaps currently prevent direct replacement.
+
+This is an audit only. No frontend or backend implementation changes are included in AFIR-02.
+
+## Current Dashboard Data Source
+
+The active dashboard is routed through:
+
+`/dashboard/:id`
+
+`DashboardPage.jsx` passes the selected dataset ID to the Dashboard component.
+
+However, the Dashboard currently loads sensor data using:
+
+`useSensorData(true)`
+
+The `true` flag enables mock mode. In this mode, `useSensorData.js` loads:
+
+`src/data/sensorData1.json`
+
+instead of requesting data from the backend.
+
+Therefore, the current dashboard remains dependent on mock sensor data regardless of the selected dashboard dataset.
+
+## Widget Dependency Mapping
+
+| Dashboard Area | Current Dependency | Existing Backend Candidate | Readiness | Current Gap / Blocker |
+|---|---|---|---|---|
+| Main dashboard dataset | `sensorData1.json` through `useSensorData(true)` | `GET /api/datasets/:name/series` | Partially replaceable | Dashboard is explicitly configured for mock mode and does not currently use the selected dataset to request live series data |
+| Available streams | Stream names derived locally by `useStreamNames(data)` | Dataset series data / available metrics support | Partially replaceable | Stream list is currently derived from mock-loaded rows |
+| Time range | `useTimeRange(data)` extracts `created_at` locally | `GET /api/datasets/:name/timestamps` | Replaceable candidate | Timestamp API exists but is not connected to the dashboard |
+| Time and entry filtering | `useFilteredData()` filters mock-loaded rows locally | `POST /api/datasets/:name/series/filter` for metric filtering | Partially replaceable | Existing backend filter supports metric selection, while time range, entry ID and interval sampling are currently frontend-side operations |
+| Stream statistics | `StreamStats.jsx` calculates min, max, average and count locally | Existing data-profile functionality | Partially replaceable | Current widget calculates statistics from frontend data rather than requesting backend profile results |
+| Correlation analysis | Frontend correlation utilities operate on filtered data | `POST /api/top-correlated-pair` | Partially replaceable | Existing correlation route belongs to the mock-data service and is not dataset-aware |
+| Most correlated pair | `MostCorrelatedPair.jsx` calculates the pair locally | `POST /api/top-correlated-pair` | Partially replaceable | Backend candidate exists but currently operates on mock/processed data rather than a selected database dataset |
+| Scatter plot | `ScatterPlot.jsx` consumes filtered frontend data | `GET /api/datasets/:name/series` | Partially replaceable | Visualization can consume live wide-format rows, but live dataset data is not currently wired into Dashboard |
+| Line chart | `Chart.jsx` consumes filtered frontend data | `GET /api/datasets/:name/series` | Partially replaceable | Chart itself is data-source independent, but its current input originates from the mock dataset |
+| Generic analysis | Frontend analysis functionality | `POST /api/analyse` | Blocked for real analysis | Backend analyse service is currently a placeholder that echoes the submitted payload |
+
+## Key Findings
+
+1. The active Dashboard is currently mock-dependent at its primary data-loading point.
+
+2. `DashboardPage` identifies a selected dataset through the route, but the Dashboard does not currently use that selection to retrieve the corresponding live time-series dataset.
+
+3. Most dashboard widgets are not inherently tied to mock data. They operate on data passed into them and could potentially consume compatible live wide-format rows.
+
+4. The backend already provides a dataset-aware series endpoint:
+
+   `GET /api/datasets/:name/series`
+
+   This endpoint is the strongest candidate for future replacement of the dashboard's primary mock dataset.
+
+5. The backend series service produces wide-format records containing:
+
+   - `created_at`
+   - `entry_id`
+   - dynamic metric fields
+
+   This structure closely matches the format expected by the current frontend hooks and visualisation components.
+
+6. A dataset timestamp endpoint also exists:
+
+   `GET /api/datasets/:name/timestamps`
+
+   This could support future time-range integration.
+
+7. Some existing routes such as `/api/streams`, `/api/data-profile`, and `/api/top-correlated-pair` remain tied to the existing mock/processed-data path and should not automatically be treated as production dataset-aware replacements.
+
+8. `POST /api/analyse` is currently a placeholder and does not provide real statistical or ML analysis.
+
+## AFIR-02 Classification
+
+Current frontend state: **Mock-dependent**
+
+Live integration potential: **Partially replaceable using existing backend capabilities**
+
+Primary integration gap: **The active dashboard is not wired to dataset-aware backend APIs**
+
+## Scope Decision
+
+AFIR-02 documents the current dependency state only.
+
+No mock dependencies were removed and no frontend/backend implementation was modified as part of this audit. Follow-up integration work should be handled through separate implementation tasks.

--- a/backend/docs/mvp/mvp-tracker.md
+++ b/backend/docs/mvp/mvp-tracker.md
@@ -86,3 +86,31 @@ Primary integration gap: **The active dashboard is not wired to dataset-aware ba
 AFIR-02 documents the current dependency state only.
 
 No mock dependencies were removed and no frontend/backend implementation was modified as part of this audit. Follow-up integration work should be handled through separate implementation tasks.
+
+# AFI-07 Response Standards Progress
+
+## Objective
+
+Define consistent frontend-ready API response structures for the core backend endpoints so the frontend can consume predictable payloads during future integration.
+
+## Progress
+
+- Reviewed the existing backend API routes documented during AFIR-02.
+- Defined standard response examples for series, analytics, alerts, and error responses.
+- Added representative payloads in `backend/docs/mvp/evidence/api-samples.json`.
+- Proposed a consistent response structure using:
+  - `success`
+  - `data`
+  - `message`
+  - `error`
+- Confirmed that the proposed structures support frontend integration without requiring changes to the current mock-data implementation.
+
+## Deliverables
+
+- Updated `backend/docs/mvp/api-contract.md`
+- Created `backend/docs/mvp/evidence/api-samples.json`
+- Updated `backend/docs/mvp/mvp-tracker.md`
+
+## Status
+
+Task completed and ready for review.

--- a/new-frontend/frontend/src/components/Dashboard.jsx
+++ b/new-frontend/frontend/src/components/Dashboard.jsx
@@ -14,8 +14,11 @@ import ScatterPlot from './ScatterPlot.jsx';
 import { calculateCorrelation } from '../utils/correlationUtils.js';
 import TimeRangePanel from './TimeRangePanel.jsx';
 
-const Dashboard = () => {
-  const { data, loading, error } = useSensorData(true);
+const Dashboard = ({ datasetName }) => {
+  const { data, loading, error } = useSensorData(
+  false,
+  `/api/datasets/${encodeURIComponent(datasetName)}/series`
+);
   const streamNames = useStreamNames(data);
   const { timeOptions, minTime, maxTime } = useTimeRange(data);
 

--- a/new-frontend/frontend/src/pages/DashboardPage.jsx
+++ b/new-frontend/frontend/src/pages/DashboardPage.jsx
@@ -3,20 +3,20 @@ import Dashboard from "../components/Dashboard";
 import "./DashboardPage.css";
 
 const DashboardPage = () => {
-  const { id } = useParams();
+  const { id: datasetName } = useParams();
 
   return (
     <main className="dashboard-page-shell">
       <section className="dashboard-page-hero">
         <div className="dashboard-page-badge">Sensor Dashboard</div>
-        <h1>{id} Dashboard</h1>
+        <h1>{datasetName} Dashboard</h1>
         <p>
           Explore time-series data, stream behaviour, correlations and summary
           insights in one structured view.
         </p>
       </section>
 
-      <Dashboard datasetId={id} />
+      <Dashboard datasetName={datasetName} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- Updated DashboardPage to pass datasetName to Dashboard.
- Updated Dashboard to use the live dataset series endpoint.
- Updated the API contract with the dataset series request and response using the dataset name/slug.

## Testing
- Backend starts successfully.
- Frontend builds successfully.
- End-to-end dashboard verification could not be completed locally because OTP authentication is required.