### PR TITLE
add dashboard sensor mock responses

### DIFF
--- a/new-frontend/frontend/src/mocks/sensors/emptyResponse.json
+++ b/new-frontend/frontend/src/mocks/sensors/emptyResponse.json
@@ -1,0 +1,9 @@
+{
+  "dataset": "sensor1",
+  "rowCount": 0,
+  "metadata": {
+    "display_name": "Environmental Sensor",
+    "streams": []
+  },
+  "rows": []
+}

--- a/new-frontend/frontend/src/mocks/sensors/errorResponse.json
+++ b/new-frontend/frontend/src/mocks/sensors/errorResponse.json
@@ -1,0 +1,5 @@
+{
+  "error": "Sensor data service is temporarily unavailable.",
+  "code": "SERVICE_UNAVAILABLE",
+  "correlationId": "mock-service-001"
+}

--- a/new-frontend/frontend/src/mocks/sensors/invalidDataResponse.json
+++ b/new-frontend/frontend/src/mocks/sensors/invalidDataResponse.json
@@ -1,0 +1,5 @@
+{
+  "error": "Invalid query parameters provided.",
+  "code": "VALIDATION_ERROR",
+  "correlationId": "mock-validation-001"
+}

--- a/new-frontend/frontend/src/mocks/sensors/sensor1Response.json
+++ b/new-frontend/frontend/src/mocks/sensors/sensor1Response.json
@@ -1,0 +1,87 @@
+{
+  "dataset": "sensor1",
+  "rowCount": 5,
+  "metadata": {
+    "display_name": "Environmental Sensor",
+    "streams": [
+      {
+        "id": "temperature",
+        "name": "Temperature",
+        "unit": null
+      },
+      {
+        "id": "humidity",
+        "name": "Humidity",
+        "unit": null
+      },
+      {
+        "id": "pressure",
+        "name": "Pressure",
+        "unit": null
+      }
+    ],
+    "statistics": {
+      "temperature": {
+        "latest": 23.8,
+        "min": 22.4,
+        "max": 23.8,
+        "average": 23.12,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "humidity": {
+        "latest": 54,
+        "min": 54,
+        "max": 58,
+        "average": 56,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "pressure": {
+        "latest": 1011.5,
+        "min": 1011.5,
+        "max": 1012.3,
+        "average": 1011.9,
+        "valid_count": 5,
+        "missing_count": 0
+      }
+    }
+  },
+  "rows": [
+    {
+      "entry_id": 1,
+      "created_at": "2026-08-07T06:00:00.000Z",
+      "temperature": 22.4,
+      "humidity": 58,
+      "pressure": 1012.3
+    },
+    {
+      "entry_id": 2,
+      "created_at": "2026-08-07T06:05:00.000Z",
+      "temperature": 22.8,
+      "humidity": 57,
+      "pressure": 1012.1
+    },
+    {
+      "entry_id": 3,
+      "created_at": "2026-08-07T06:10:00.000Z",
+      "temperature": 23.1,
+      "humidity": 56,
+      "pressure": 1011.9
+    },
+    {
+      "entry_id": 4,
+      "created_at": "2026-08-07T06:15:00.000Z",
+      "temperature": 23.5,
+      "humidity": 55,
+      "pressure": 1011.7
+    },
+    {
+      "entry_id": 5,
+      "created_at": "2026-08-07T06:20:00.000Z",
+      "temperature": 23.8,
+      "humidity": 54,
+      "pressure": 1011.5
+    }
+  ]
+}

--- a/new-frontend/frontend/src/mocks/sensors/sensor2Response.json
+++ b/new-frontend/frontend/src/mocks/sensors/sensor2Response.json
@@ -1,0 +1,87 @@
+{
+  "dataset": "sensor2",
+  "rowCount": 5,
+  "metadata": {
+    "display_name": "Multi-Stream Sensor",
+    "streams": [
+      {
+        "id": "metric_a",
+        "name": "Metric A",
+        "unit": null
+      },
+      {
+        "id": "metric_b",
+        "name": "Metric B",
+        "unit": null
+      },
+      {
+        "id": "metric_c",
+        "name": "Metric C",
+        "unit": null
+      }
+    ],
+    "statistics": {
+      "metric_a": {
+        "latest": 16.5,
+        "min": 12.5,
+        "max": 16.5,
+        "average": 14.46,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "metric_b": {
+        "latest": 40.2,
+        "min": 40.2,
+        "max": 44.2,
+        "average": 42.24,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "metric_c": {
+        "latest": 9.4,
+        "min": 7.8,
+        "max": 9.4,
+        "average": 8.58,
+        "valid_count": 5,
+        "missing_count": 0
+      }
+    }
+  },
+  "rows": [
+    {
+      "entry_id": 1,
+      "created_at": "2026-08-07T06:00:00.000Z",
+      "metric_a": 12.5,
+      "metric_b": 44.2,
+      "metric_c": 7.8
+    },
+    {
+      "entry_id": 2,
+      "created_at": "2026-08-07T06:05:00.000Z",
+      "metric_a": 13.4,
+      "metric_b": 43.2,
+      "metric_c": 8.1
+    },
+    {
+      "entry_id": 3,
+      "created_at": "2026-08-07T06:10:00.000Z",
+      "metric_a": 14.5,
+      "metric_b": 42.1,
+      "metric_c": 8.6
+    },
+    {
+      "entry_id": 4,
+      "created_at": "2026-08-07T06:15:00.000Z",
+      "metric_a": 15.4,
+      "metric_b": 41.5,
+      "metric_c": 9.0
+    },
+    {
+      "entry_id": 5,
+      "created_at": "2026-08-07T06:20:00.000Z",
+      "metric_a": 16.5,
+      "metric_b": 40.2,
+      "metric_c": 9.4
+    }
+  ]
+}

--- a/new-frontend/frontend/src/mocks/sensors/sensor3Response.json
+++ b/new-frontend/frontend/src/mocks/sensors/sensor3Response.json
@@ -1,0 +1,87 @@
+{
+  "dataset": "sensor3",
+  "rowCount": 5,
+  "metadata": {
+    "display_name": "IoT Monitoring Sensor",
+    "streams": [
+      {
+        "id": "device_metric_a",
+        "name": "Device Metric A",
+        "unit": null
+      },
+      {
+        "id": "device_metric_b",
+        "name": "Device Metric B",
+        "unit": null
+      },
+      {
+        "id": "device_metric_c",
+        "name": "Device Metric C",
+        "unit": null
+      }
+    ],
+    "statistics": {
+      "device_metric_a": {
+        "latest": 47,
+        "min": 31,
+        "max": 47,
+        "average": 38.4,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "device_metric_b": {
+        "latest": 73,
+        "min": 62,
+        "max": 73,
+        "average": 66.8,
+        "valid_count": 5,
+        "missing_count": 0
+      },
+      "device_metric_c": {
+        "latest": 32,
+        "min": 18,
+        "max": 32,
+        "average": 24.4,
+        "valid_count": 5,
+        "missing_count": 0
+      }
+    }
+  },
+  "rows": [
+    {
+      "entry_id": 1,
+      "created_at": "2026-08-07T06:00:00.000Z",
+      "device_metric_a": 31,
+      "device_metric_b": 62,
+      "device_metric_c": 18
+    },
+    {
+      "entry_id": 2,
+      "created_at": "2026-08-07T06:05:00.000Z",
+      "device_metric_a": 34,
+      "device_metric_b": 64,
+      "device_metric_c": 21
+    },
+    {
+      "entry_id": 3,
+      "created_at": "2026-08-07T06:10:00.000Z",
+      "device_metric_a": 38,
+      "device_metric_b": 66,
+      "device_metric_c": 24
+    },
+    {
+      "entry_id": 4,
+      "created_at": "2026-08-07T06:15:00.000Z",
+      "device_metric_a": 42,
+      "device_metric_b": 69,
+      "device_metric_c": 27
+    },
+    {
+      "entry_id": 5,
+      "created_at": "2026-08-07T06:20:00.000Z",
+      "device_metric_a": 47,
+      "device_metric_b": 73,
+      "device_metric_c": 32
+    }
+  ]
+}


### PR DESCRIPTION
Added mock sensor responses to support dashboard development and testing.

- Added separate mock responses for Sensor 1, Sensor 2 and Sensor 3.
- Added empty-data response.
- Added invalid-data response.
- Added service error response.
- Added different mock sensor data so different dashboard routes can display different information.