### PR TITLE
Validate end-to-end MVP demo path

### DIFF
--- a/backend/docs/mvp/evidence/e2e-results.csv
+++ b/backend/docs/mvp/evidence/e2e-results.csv
@@ -1,0 +1,9 @@
+Step,Scenario,Area,Method,Endpoint Or Check,Expected Result,Actual Result,Status,Owner,Priority
+"1","Success","Dataset API","GET","/api/datasets","thingspeak-live appears in dataset list","thingspeak-live found","PASS","Backend","High"
+"2","Success","Series API","GET","/api/datasets/thingspeak-live/series","Live persisted rows are returned","Returned 289 rows","PASS","Backend","High"
+"3","Empty data","Series API","GET","/api/datasets/not-a-real-dataset/series","Clear missing dataset response","Dataset not found or empty","PASS","Backend","Medium"
+"4","Validation error","Filter API","POST","/api/datasets/thingspeak-live/series/filter","Invalid request is rejected","streamNames must be a non-empty array","PASS","Backend","Medium"
+"5","Success","Filter API","POST","/api/datasets/thingspeak-live/series/filter","Filtered live rows are returned","Returned 289 filtered rows","PASS","Backend","High"
+"6","Incomplete","Analytics API","POST","/api/analyse","Real analytics execution is performed","Returned placeholder message only","BLOCKED","Backend API / Analytics","High"
+"7","Incomplete","Alert persistence","N/A","Backend schema/routes","Generated alerts are persisted","No alerts table found","BLOCKED","Backend API / Analytics","High"
+"8","Incomplete","Dashboard rendering","N/A","Frontend dashboard","Dashboard renders live backend data","Dashboard uses useSensorData(true)","BLOCKED","Frontend","High"

--- a/backend/docs/mvp/test-plan.md
+++ b/backend/docs/mvp/test-plan.md
@@ -1,0 +1,183 @@
+# MVP End-to-End Test Plan
+
+## Ticket
+
+Validate End-To-End MVP Demo Path
+
+## Purpose
+
+Validate the live MVP demo path from live ingestion through database persistence, backend APIs, analytics, alert persistence, and frontend dashboard rendering.
+
+## Environment
+
+- Backend URL: `http://localhost:3000`
+- Frontend URL: `http://localhost:5173`
+- Database: PostgreSQL
+- Live data source: ThingSpeak public channel `12397`
+- Dataset name: `thingspeak-live`
+
+## Required Setup
+
+1. PostgreSQL must be running.
+2. The backend `.env` file must include database settings.
+3. The backend `.env` file must include ThingSpeak settings.
+
+```env
+THINGSPEAK_CHANNEL_ID=12397
+THINGSPEAK_RESULTS=10
+THINGSPEAK_POLL_INTERVAL_MS=15000
+THINGSPEAK_MAX_RETRIES=3
+THINGSPEAK_RETRY_DELAY_MS=2000
+THINGSPEAK_DATASET_NAME=thingspeak-live
+```
+
+4. JWT settings must exist for protected API paths.
+
+```env
+JWT_SECRET=dev_secret_key
+REFRESH_TOKEN_SECRET=dev_refresh_secret_key
+TOKEN_EXPIRY=1h
+```
+
+## Test Scope
+
+The smoke validation covers the critical backend demo path where practical:
+
+- Live dataset availability
+- Persisted time-series access
+- Stable API route behaviour
+- Success response handling
+- Empty-data response handling
+- Validation-error response handling
+- Analytics route availability
+- Alert persistence readiness
+- Dashboard live-data readiness
+
+## Test Flow
+
+1. Start the backend.
+2. Confirm ThingSpeak live ingestion succeeds.
+3. Confirm live data is persisted in PostgreSQL.
+4. Confirm stable backend API routes return live data.
+5. Confirm success, empty-data, validation-error, and service-failure outcomes where practical.
+6. Confirm analytics execution readiness.
+7. Confirm alert persistence readiness.
+8. Confirm dashboard rendering readiness against live data.
+9. Capture dashboard proof screenshot once live dashboard data is available.
+10. Record blockers with owner and priority.
+
+## Automated Smoke Test
+
+Run from the project root while the backend is running:
+
+```powershell
+node backend/tests/mvp-e2e-smoke.js
+```
+
+The script writes results to:
+
+```text
+backend/docs/mvp/evidence/e2e-results.csv
+```
+
+## Discovery Notes
+
+Before the smoke test was added, the live path was checked using backend logs and Thunder Client. These checks confirmed that live ingestion, database persistence, dataset APIs, series APIs, empty-data handling, validation-error handling, and filter success handling are working.
+
+The same discovery confirmed that analytics orchestration, alert persistence, and live dashboard rendering are still incomplete in the current implementation.
+
+## Results Summary
+
+### Passed
+
+- Live ingestion: ThingSpeak polling inserted rows for dataset `thingspeak-live`.
+- DB persistence: Dataset API returned `thingspeak-live`.
+- Stable API routes: Dataset and series endpoints returned live persisted data.
+- Empty-data outcome: Missing dataset returned a clear error response.
+- Validation-error outcome: Invalid filter request returned `400 Bad Request`.
+- Filter success outcome: Valid filter request returned selected live fields.
+- Re-runnable smoke evidence: `backend/tests/mvp-e2e-smoke.js` writes `backend/docs/mvp/evidence/e2e-results.csv`.
+
+### Blocked
+
+- Analytics execution: `/api/analyse` currently returns placeholder output only.
+- Alert persistence: No alert table, route, controller, service, or repository exists in the active backend.
+- Dashboard live rendering: Dashboard currently uses local mock data through `useSensorData(true)`.
+- Dashboard proof screenshot: Cannot be honestly captured against live data until the dashboard is connected to the backend API.
+
+## Blockers
+
+### 1. Analytics Orchestration
+
+- Priority: High
+- Owner: Backend API / Analytics
+- Blocker: Analytics orchestration is placeholder-only.
+- Evidence: `POST /api/analyse` returns `Analysis completed (placeholder)`.
+
+### 2. Alert Persistence
+
+- Priority: High
+- Owner: Backend API / Analytics
+- Blocker: Alert persistence is not implemented.
+- Evidence: No alert persistence route, table, service, controller, or repository exists in the active backend.
+
+### 3. Dashboard Live Data Cutover
+
+- Priority: High
+- Owner: Frontend
+- Blocker: Dashboard is not connected to live backend data.
+- Evidence: Dashboard calls `useSensorData(true)` and loads local mock JSON.
+
+### 4. Dashboard Proof Screenshot
+
+- Priority: High
+- Owner: Frontend / QA
+- Blocker: `dashboard-proof.png` cannot be captured against live data yet.
+- Evidence: Current dashboard renders mock data, not the live `thingspeak-live` backend series.
+
+### 5. Service-Failure Coverage
+
+- Priority: Medium
+- Owner: QA / Backend
+- Blocker: Service-failure behaviour is not fully covered by the smoke script.
+- Evidence: A controlled failure mode or test-mode dependency override is needed to test service failure safely and repeatably.
+
+## Implementation Tickets Required
+
+### High Priority
+
+- Backend API / Analytics: Replace placeholder `/api/analyse` response with real analytics orchestration against live dataset rows.
+- Backend API / Analytics: Add alert persistence table, repository, service, and route for generated analytics alerts.
+- Frontend: Cut dashboard over from local mock data to live backend series API.
+- Frontend / QA: Capture `backend/docs/mvp/evidence/dashboard-proof.png` after the dashboard renders live backend data.
+
+### Medium Priority
+
+- QA / Backend: Add service-failure smoke coverage using a controlled dependency failure or test-mode configuration.
+
+## Acceptance Criteria Status
+
+### Full Live MVP Flow Is Executed End To End
+
+- Status: BLOCKED
+- Notes: Ingestion, persistence, and APIs pass. Analytics, alert persistence, and dashboard live rendering are blocked.
+
+### Live Responses And Persisted Alerts Are Verified With Evidence
+
+- Status: BLOCKED
+- Notes: Live API responses are verified. Persisted alerts are unavailable because alert persistence is missing.
+
+### Dashboard Proof Is Captured Against Live Data
+
+- Status: BLOCKED
+- Notes: Dashboard currently renders mock data, so live dashboard proof cannot be captured honestly yet.
+
+### Re-Runnable Test Steps Or Test Code Cover The Critical Demo Path
+
+- Status: PASS
+- Notes: `backend/tests/mvp-e2e-smoke.js` runs smoke checks and writes `backend/docs/mvp/evidence/e2e-results.csv`.
+
+### Remaining Blockers Are Recorded And Assigned
+
+- Status: PASS
+- Notes: Blockers are listed with owner and priority.

--- a/backend/tests/mvp-e2e-smoke.js
+++ b/backend/tests/mvp-e2e-smoke.js
@@ -1,0 +1,289 @@
+const fs = require("fs");
+const path = require("path");
+
+const BASE_URL = process.env.MVP_BASE_URL || "http://localhost:3000";
+const DATASET = process.env.MVP_DATASET || "thingspeak-live";
+
+const evidenceDir = path.join(__dirname, "..", "docs", "mvp", "evidence");
+const resultsPath = path.join(evidenceDir, "e2e-results.csv");
+
+const rows = [];
+
+function add(step, scenario, area, method, check, expected, actual, status, owner, priority) {
+  rows.push({ step, scenario, area, method, check, expected, actual, status, owner, priority });
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
+async function postJson(url, payload) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
+function csvEscape(value) {
+  return `"${String(value ?? "").replaceAll('"', '""')}"`;
+}
+
+function getStatusSummary() {
+  return rows.reduce(
+    (counts, row) => {
+      counts[row.status] = (counts[row.status] || 0) + 1;
+      return counts;
+    },
+    {}
+  );
+}
+
+function color(text, code) {
+  return `\x1b[${code}m${text}\x1b[0m`;
+}
+
+function green(text) {
+  return color(text, 32);
+}
+
+function yellow(text) {
+  return color(text, 33);
+}
+
+function red(text) {
+  return color(text, 31);
+}
+
+function bold(text) {
+  return color(text, 1);
+}
+
+function formatStatus(status) {
+  if (status === "PASS") return green(status);
+  if (status === "BLOCKED") return yellow(status);
+  return red(status);
+}
+
+function getStatusIcon(status) {
+  if (status === "PASS") return green("✓");
+  if (status === "BLOCKED") return yellow("!");
+  return red("x");
+}
+
+async function run() {
+  const datasets = await getJson(`${BASE_URL}/api/datasets`);
+  const hasDataset =
+    Array.isArray(datasets.body) &&
+    datasets.body.some((dataset) => dataset.name === DATASET);
+
+  add(
+    1,
+    "Success",
+    "Dataset API",
+    "GET",
+    "/api/datasets",
+    `${DATASET} appears in dataset list`,
+    hasDataset ? `${DATASET} found` : `${DATASET} missing`,
+    hasDataset ? "PASS" : "FAIL",
+    "Backend",
+    "High"
+  );
+
+  const series = await getJson(`${BASE_URL}/api/datasets/${DATASET}/series`);
+  const hasRows = Array.isArray(series.body) && series.body.length > 0;
+
+  add(
+    2,
+    "Success",
+    "Series API",
+    "GET",
+    `/api/datasets/${DATASET}/series`,
+    "Live persisted rows are returned",
+    hasRows ? `Returned ${series.body.length} rows` : JSON.stringify(series.body),
+    hasRows ? "PASS" : "FAIL",
+    "Backend",
+    "High"
+  );
+
+  const empty = await getJson(`${BASE_URL}/api/datasets/not-a-real-dataset/series`);
+  const emptyHandled = Boolean(empty.body && empty.body.error);
+
+  add(
+    3,
+    "Empty data",
+    "Series API",
+    "GET",
+    "/api/datasets/not-a-real-dataset/series",
+    "Clear missing dataset response",
+    emptyHandled ? empty.body.error : JSON.stringify(empty.body),
+    emptyHandled ? "PASS" : "FAIL",
+    "Backend",
+    "Medium"
+  );
+
+  const invalid = await postJson(
+    `${BASE_URL}/api/datasets/${DATASET}/series/filter`,
+    {}
+  );
+  const validationHandled = invalid.status === 400 && invalid.body.error;
+
+  add(
+    4,
+    "Validation error",
+    "Filter API",
+    "POST",
+    `/api/datasets/${DATASET}/series/filter`,
+    "Invalid request is rejected",
+    validationHandled ? invalid.body.error : JSON.stringify(invalid.body),
+    validationHandled ? "PASS" : "FAIL",
+    "Backend",
+    "Medium"
+  );
+
+  const filtered = await postJson(
+    `${BASE_URL}/api/datasets/${DATASET}/series/filter`,
+    {
+      streamNames: ["field3", "field4", "field6"],
+    }
+  );
+  const filteredOk =
+    filtered.status === 200 &&
+    Array.isArray(filtered.body) &&
+    filtered.body.length > 0;
+
+  add(
+    5,
+    "Success",
+    "Filter API",
+    "POST",
+    `/api/datasets/${DATASET}/series/filter`,
+    "Filtered live rows are returned",
+    filteredOk
+      ? `Returned ${filtered.body.length} filtered rows`
+      : JSON.stringify(filtered.body),
+    filteredOk ? "PASS" : "FAIL",
+    "Backend",
+    "High"
+  );
+
+  const analyse = await postJson(`${BASE_URL}/api/analyse`, {
+    datasetName: DATASET,
+    streamNames: ["field3", "field4", "field6"],
+  });
+  const placeholder = JSON.stringify(analyse.body).includes("placeholder");
+
+  add(
+    6,
+    "Incomplete",
+    "Analytics API",
+    "POST",
+    "/api/analyse",
+    "Real analytics execution is performed",
+    placeholder ? "Returned placeholder message only" : JSON.stringify(analyse.body),
+    placeholder ? "BLOCKED" : "PASS",
+    "Backend API / Analytics",
+    "High"
+  );
+
+  const schemaPath = path.join(__dirname, "..", "src", "db", "schema.sql");
+  const schema = fs.readFileSync(schemaPath, "utf8");
+  const hasAlertsTable = /CREATE TABLE\s+alerts/i.test(schema);
+
+  add(
+    7,
+    "Incomplete",
+    "Alert persistence",
+    "N/A",
+    "Backend schema/routes",
+    "Generated alerts are persisted",
+    hasAlertsTable ? "Alerts table found" : "No alerts table found",
+    hasAlertsTable ? "PASS" : "BLOCKED",
+    "Backend API / Analytics",
+    "High"
+  );
+
+  const dashboardPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "new-frontend",
+    "frontend",
+    "src",
+    "components",
+    "Dashboard.jsx"
+  );
+  const dashboard = fs.readFileSync(dashboardPath, "utf8");
+  const usesMock = dashboard.includes("useSensorData(true)");
+
+  add(
+    8,
+    "Incomplete",
+    "Dashboard rendering",
+    "N/A",
+    "Frontend dashboard",
+    "Dashboard renders live backend data",
+    usesMock
+      ? "Dashboard uses useSensorData(true)"
+      : "Dashboard is not hardcoded to mock mode",
+    usesMock ? "BLOCKED" : "PASS",
+    "Frontend",
+    "High"
+  );
+
+  fs.mkdirSync(evidenceDir, { recursive: true });
+
+  const header =
+    "Step,Scenario,Area,Method,Endpoint Or Check,Expected Result,Actual Result,Status,Owner,Priority";
+
+  const csv = [
+    header,
+    ...rows.map((row) =>
+      [
+        row.step,
+        row.scenario,
+        row.area,
+        row.method,
+        row.check,
+        row.expected,
+        row.actual,
+        row.status,
+        row.owner,
+        row.priority,
+      ]
+        .map(csvEscape)
+        .join(",")
+    ),
+  ].join("\n");
+
+  fs.writeFileSync(resultsPath, csv);
+
+  const summary = getStatusSummary();
+  const total = rows.length;
+
+  console.log("");
+  console.log(bold("MVP E2E Smoke Test"));
+  console.log("");
+
+  rows.forEach((row) => {
+    console.log(`${getStatusIcon(row.status)} ${row.area} - ${formatStatus(row.status)}`);
+  });
+
+  console.log("");
+  console.log(`Checks: ${total}`);
+  console.log(`Passed: ${green(summary.PASS || 0)}`);
+  console.log(`Failed: ${red(summary.FAIL || 0)}`);
+  console.log(`Blocked: ${yellow(summary.BLOCKED || 0)}`);
+  console.log("");
+  console.log(`Evidence: ${resultsPath}`);
+}
+
+run().catch((error) => {
+  console.error(red(`MVP smoke test failed: ${error.message}`));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Added MVP E2E smoke test, test plan, and CSV evidence for the live demo validation path.

## Validation

Ran `node backend/tests/mvp-e2e-smoke.js`

Result: 5 passed, 0 failed, 3 blocked.

## Notes

Live ingestion, DB persistence, and API routes were verified. Analytics, alert persistence, and live dashboard proof remain blocked and are documented in the test plan.